### PR TITLE
Weapon Listitem Expansion

### DIFF
--- a/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/assets/AssetLoader.kt
+++ b/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/assets/AssetLoader.kt
@@ -7,7 +7,9 @@ import android.graphics.drawable.Drawable
 import android.support.v4.content.ContextCompat
 import com.gatheringhallstudios.mhworlddatabase.R
 import com.gatheringhallstudios.mhworlddatabase.data.models.*
-import com.gatheringhallstudios.mhworlddatabase.data.types.*
+import com.gatheringhallstudios.mhworlddatabase.data.types.AmmoType
+import com.gatheringhallstudios.mhworlddatabase.data.types.ArmorType
+import com.gatheringhallstudios.mhworlddatabase.data.types.CoatingType
 import com.gatheringhallstudios.mhworlddatabase.data.types.WeaponType
 import com.gatheringhallstudios.mhworlddatabase.util.getDrawableCompat
 
@@ -134,6 +136,10 @@ object AssetLoader {
         }
 
         return ctx.getVectorDrawable(name, "rare$rarity")
+    }
+
+    fun loadElementIcon(element: String?): Drawable? {
+        return ctx.getDrawableCompat(ElementRegistry(element))
     }
 
     fun loadNoteFromChar(type: Char, noteNumber: Int): Drawable? {

--- a/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/assets/AssetRegistry.kt
+++ b/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/assets/AssetRegistry.kt
@@ -93,6 +93,19 @@ val VectorRegistry = createRegistry(
         "Wing" to R.xml.ic_items_wing_base
 )
 
+val ElementRegistry = fun(element: String?) = when(element) {
+    "Fire" -> R.drawable.ic_element_fire
+    "Dragon" -> R.drawable.ic_element_dragon
+    "Poison" -> R.drawable.ic_status_poison
+    "Water" -> R.drawable.ic_element_water
+    "Thunder" -> R.drawable.ic_element_thunder
+    "Ice" -> R.drawable.ic_element_ice
+    "Blast" -> R.drawable.ic_status_blast
+    "Paralysis" -> R.drawable.ic_status_paralysis
+    "Sleep" -> R.drawable.ic_status_sleep
+    else -> R.drawable.ic_ui_slot_none
+}
+
 val SlotEmptyRegistry = fun(slot: Int) = when(slot) {
     1 -> R.drawable.ic_ui_slot_1_empty
     2 -> R.drawable.ic_ui_slot_2_empty

--- a/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/features/weapons/WeaponTreeListAdapterDelegate.kt
+++ b/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/features/weapons/WeaponTreeListAdapterDelegate.kt
@@ -6,6 +6,7 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.Space
@@ -197,6 +198,8 @@ class WeaponTreeListAdapterDelegate(
 
         private fun createImageView(context: Context, resource: Int): ImageView {
             val imageView = ImageView(context)
+            imageView.scaleType = ImageView.ScaleType.FIT_XY
+            imageView.layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT)
             imageView.setPadding(0, 0, 0, 0)
             imageView.setImageResource(resource)
             return imageView

--- a/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/features/weapons/WeaponTreeListAdapterDelegate.kt
+++ b/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/features/weapons/WeaponTreeListAdapterDelegate.kt
@@ -1,7 +1,6 @@
 package com.gatheringhallstudios.mhworlddatabase.features.weapons
 
 import android.content.Context
-import android.graphics.drawable.Drawable
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
@@ -101,7 +100,7 @@ class WeaponTreeListAdapterDelegate(
             if (weapon.element1 != null){
                 val elementView = CompactStatCell(
                         view.context,
-                        getElementIcon(view.context, weapon.element1),
+                        AssetLoader.loadElementIcon(weapon.element1),
                         createElementString(weapon.element1_attack, weapon.element_hidden))
 
                 if (weapon.element_hidden) {
@@ -201,22 +200,6 @@ class WeaponTreeListAdapterDelegate(
             imageView.setPadding(0, 0, 0, 0)
             imageView.setImageResource(resource)
             return imageView
-        }
-
-        // todo: there is already a registry for this...or there should be...
-        private fun getElementIcon(context: Context, element: String?): Drawable? {
-            return when (element) {
-                "Fire" -> context.getDrawableCompat(R.drawable.ic_element_fire)
-                "Dragon" -> context.getDrawableCompat(R.drawable.ic_element_dragon)
-                "Poison" -> context.getDrawableCompat(R.drawable.ic_status_poison)
-                "Water" -> context.getDrawableCompat(R.drawable.ic_element_water)
-                "Thunder" -> context.getDrawableCompat(R.drawable.ic_element_thunder)
-                "Ice" -> context.getDrawableCompat(R.drawable.ic_element_ice)
-                "Blast" -> context.getDrawableCompat(R.drawable.ic_status_blast)
-                "Paralysis" -> context.getDrawableCompat(R.drawable.ic_status_paralysis)
-                "Sleep" -> context.getDrawableCompat(R.drawable.ic_status_sleep)
-                else -> context.getDrawableCompat(R.drawable.ic_ui_slot_none)
-            }
         }
     }
 }

--- a/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/features/weapons/detail/WeaponDetailFragment.kt
+++ b/app/src/main/java/com/gatheringhallstudios/mhworlddatabase/features/weapons/detail/WeaponDetailFragment.kt
@@ -2,7 +2,6 @@ package com.gatheringhallstudios.mhworlddatabase.features.weapons.detail
 
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
-import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
@@ -78,7 +77,7 @@ class WeaponDetailFragment : Fragment() {
 
         // Set elemental attack values
         element_value.text = createElementString(weapon.element1_attack, weapon.element_hidden)
-        element_icon.setImageDrawable(getElementIcon(weapon.element1))
+        element_icon.setImageDrawable(AssetLoader.loadElementIcon(weapon.element1))
         element_type_value.text = weapon.element1 //TODO: This element string needs to be localized in the DB
         if (weapon.element_hidden) {
             element_layout.alpha = 0.5.toFloat()
@@ -103,21 +102,6 @@ class WeaponDetailFragment : Fragment() {
         return when (element_hidden) {
             true -> "(${workString})"
             false -> workString.toString()
-        }
-    }
-
-    private fun getElementIcon(element: String?): Drawable? {
-        return when (element) {
-            "Fire" -> context!!.getDrawableCompat(R.drawable.ic_element_fire)
-            "Dragon" -> context!!.getDrawableCompat(R.drawable.ic_element_dragon)
-            "Poison" -> context!!.getDrawableCompat(R.drawable.ic_status_poison)
-            "Water" -> context!!.getDrawableCompat(R.drawable.ic_element_water)
-            "Thunder" -> context!!.getDrawableCompat(R.drawable.ic_element_thunder)
-            "Ice" -> context!!.getDrawableCompat(R.drawable.ic_element_ice)
-            "Blast" -> context!!.getDrawableCompat(R.drawable.ic_status_blast)
-            "Paralysis" -> context!!.getDrawableCompat(R.drawable.ic_status_paralysis)
-            "Sleep" -> context!!.getDrawableCompat(R.drawable.ic_status_sleep)
-            else -> context!!.getDrawableCompat(R.drawable.ic_ui_slot_none)
         }
     }
 
@@ -252,7 +236,7 @@ class WeaponDetailFragment : Fragment() {
         //Draw sharpness bar/hide it for weapons that don't have it
         populateSharpness(weapon.sharpnessData, view)
 
-        view.findViewById<ImageView>(R.id.phial_element_icon).setImageDrawable(getElementIcon(weapon.phial.toString()))
+        view.findViewById<ImageView>(R.id.phial_element_icon).setImageDrawable(AssetLoader.loadElementIcon(weapon.phial.toString()))
         view.findViewById<TextView>(R.id.phial_type_value).text = when (weapon.phial) {
             PhialType.NONE -> ""
             PhialType.EXHAUST -> getString(R.string.weapon_charge_blade_exhaust)

--- a/app/src/main/res/layout/listitem_weapon.xml
+++ b/app/src/main/res/layout/listitem_weapon.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/row_height_xxlarge">
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/row_height_xxlarge">
 
     <TextView
         android:id="@+id/weapon_name"

--- a/app/src/main/res/layout/listitem_weapontree.xml
+++ b/app/src/main/res/layout/listitem_weapontree.xml
@@ -9,13 +9,13 @@
     <LinearLayout
         android:id="@+id/tree_components"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:orientation="horizontal">
 
         <ImageView
             android:id="@+id/imageView"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:src="@drawable/ui_tree_node_start" />
     </LinearLayout>
 


### PR DESCRIPTION
Weapon listitems can now wrap contents. Future plan is to convert tree lines to nine-patch drawable so they scale while allowing us to pin the weapon icon to the top left instead of stretching like it does now.